### PR TITLE
Add llms.txt and raw markdown endpoints for AI agent discoverability

### DIFF
--- a/src/pages/events/[slug].md.ts
+++ b/src/pages/events/[slug].md.ts
@@ -1,0 +1,58 @@
+import { getCollection, getEntry } from "astro:content";
+import type { APIRoute } from "astro";
+
+export async function getStaticPaths() {
+  const events = await getCollection("events");
+  return events.map((event) => ({ params: { slug: event.id } }));
+}
+
+export const prerender = true;
+
+export const GET: APIRoute = async ({ params }) => {
+  const event = await getEntry("events", params.slug!);
+
+  if (!event) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const venue =
+    "event" in event.data ? event.data.event.name : event.data.podcast.name;
+  const venueHref =
+    "event" in event.data ? event.data.event.href : event.data.podcast.href;
+
+  const linkLines: string[] = [];
+  if (event.data.youtubeId) {
+    linkLines.push(
+      `- [YouTube](https://www.youtube.com/watch?v=${event.data.youtubeId})`,
+    );
+  }
+  if ("podcast" in event.data) {
+    if (event.data.podcast.spotify) {
+      linkLines.push(`- [Spotify](${event.data.podcast.spotify})`);
+    }
+    if (event.data.podcast.pocketCasts) {
+      linkLines.push(`- [Pocket Casts](${event.data.podcast.pocketCasts})`);
+    }
+  }
+  if (event.data.link) {
+    linkLines.push(`- [${event.data.link.text}](${event.data.link.href})`);
+  }
+
+  const lines: string[] = [
+    `# ${event.data.title}`,
+    "",
+    `**Date**: ${event.data.startDate}`,
+    `**Venue**: [${venue}](${venueHref})`,
+  ];
+
+  if (linkLines.length > 0) {
+    lines.push("**Links**:");
+    lines.push(...linkLines);
+  }
+
+  lines.push("", "---", "", event.body ?? "");
+
+  return new Response(lines.join("\n"), {
+    headers: { "Content-Type": "text/markdown; charset=utf-8" },
+  });
+};

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -1,0 +1,50 @@
+import { getCollection } from "astro:content";
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async () => {
+  const events = await getCollection("events");
+
+  const sortedEvents = [...events].sort(
+    (a, b) =>
+      new Date(b.data.startDate).getTime() -
+      new Date(a.data.startDate).getTime(),
+  );
+
+  const lines: string[] = [
+    "# Tyler Benfield",
+    "",
+    "> Software engineer focused on making databases and data-driven applications more approachable through education and tooling. Over 10 years of experience in consulting, startups, and large organizations. Staff Software Engineer at Prisma.",
+    "",
+    "## Pages",
+    "",
+    "- [Home](https://tylerbenfield.dev/): Bio and overview",
+    "- [Talks & Podcasts](https://tylerbenfield.dev/events): Conference talks and podcast appearances",
+    "- [Links](https://tylerbenfield.dev/links): External links and social profiles",
+    "- [Agent Experience](https://tylerbenfield.dev/agent-experience): AI coding agent skills and philosophy",
+    "",
+    "## Talks & Podcasts",
+    "",
+  ];
+
+  for (const event of sortedEvents) {
+    const url = `https://tylerbenfield.dev/events/${event.id}`;
+    const venue =
+      "event" in event.data
+        ? event.data.event.name
+        : event.data.podcast.name;
+    lines.push(
+      `- [${event.data.title}](${url}) — ${venue} (${event.data.startDate})`,
+    );
+  }
+
+  lines.push(
+    "",
+    "## Raw Content",
+    "",
+    "Markdown source for each talk or podcast is available at `/events/{slug}.md`.",
+  );
+
+  return new Response(lines.join("\n"), {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+};


### PR DESCRIPTION
Adds /llms.txt (dynamic endpoint summarizing the site per the emerging
llms.txt convention) and /events/[slug].md (prerendered raw markdown
for each talk/podcast entry so agents can retrieve clean content without
parsing HTML). No new dependencies required.