### PR TITLE
Add speaking contact section to events page

### DIFF
--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -1,6 +1,8 @@
 ---
+import { faEnvelope, faMicrophone } from "@fortawesome/free-solid-svg-icons";
 import { getCollection } from "astro:content";
 import EventTimelineEntry from "../components/EventTimelineEntry.astro";
+import FontAwesomeIcon from "../components/FontAwesomeIcon.astro";
 import Layout from "../layouts/Layout.astro";
 
 const entries = await getCollection("events");
@@ -10,6 +12,13 @@ const sorted = [...entries].sort((a, b) =>
 );
 
 const isUpcoming = (startDate: string) => startDate >= today;
+
+const topics = [
+  "Distributed systems",
+  "Platform engineering",
+  "Databases",
+  "Agentic engineering",
+];
 ---
 
 <Layout title="Talks & Podcasts | Tyler Benfield">
@@ -42,4 +51,35 @@ const isUpcoming = (startDate: string) => startDate >= today;
       </section>
     )
   }
+
+  <section class="mt-20 lg:mt-28">
+    <div class="glass gradient-border rounded-3xl p-6 sm:p-10 lg:p-12">
+      <div class="mb-6 flex items-center gap-3">
+        <FontAwesomeIcon icon={faMicrophone} class="text-2xl text-tokyo-purple" />
+        <h2 class="text-2xl font-bold tracking-tight">Invite me to speak</h2>
+      </div>
+      <p class="mb-6 text-lg leading-relaxed text-tokyo-fg-muted">
+        I'm always open to speaking at conferences, meetups, and podcasts. My
+        talks draw from hands-on experience building and scaling real systems —
+        practical lessons rather than theoretical overviews. I most often speak
+        on:
+      </p>
+      <ul class="mb-8 flex flex-wrap gap-3">
+        {
+          topics.map((topic) => (
+            <li class="rounded-full border border-tokyo-purple/30 bg-tokyo-purple/10 px-4 py-1.5 text-sm font-semibold text-tokyo-purple">
+              {topic}
+            </li>
+          ))
+        }
+      </ul>
+      <a
+        href="mailto:tyler@tylerbenfield.me?subject=Speaking%20Inquiry"
+        class="inline-flex items-center gap-2 rounded-full bg-tokyo-purple px-8 py-4 font-semibold text-tokyo-bg no-underline shadow-[0_0_30px_-8px_var(--tokyo-purple)] transition-all hover:-translate-y-0.5 hover:bg-tokyo-light-cyan hover:shadow-[0_0_40px_-6px_var(--tokyo-purple)]"
+      >
+        <FontAwesomeIcon icon={faEnvelope} />
+        Get in touch
+      </a>
+    </div>
+  </section>
 </Layout>

--- a/src/pages/events.astro
+++ b/src/pages/events.astro
@@ -37,32 +37,16 @@ const topics = [
     </p>
   </header>
 
-  {
-    sorted.length > 0 && (
-      <section>
-        <div class="flex flex-col gap-10">
-          {sorted.map((entry) => (
-            <EventTimelineEntry
-              event={entry}
-              expanded={isUpcoming(entry.data.startDate)}
-            />
-          ))}
-        </div>
-      </section>
-    )
-  }
-
-  <section class="mt-20 lg:mt-28">
+  <section class="mb-12 lg:mb-16">
     <div class="glass gradient-border rounded-3xl p-6 sm:p-10 lg:p-12">
       <div class="mb-6 flex items-center gap-3">
         <FontAwesomeIcon icon={faMicrophone} class="text-2xl text-tokyo-purple" />
         <h2 class="text-2xl font-bold tracking-tight">Invite me to speak</h2>
       </div>
       <p class="mb-6 text-lg leading-relaxed text-tokyo-fg-muted">
-        I'm always open to speaking at conferences, meetups, and podcasts. My
-        talks draw from hands-on experience building and scaling real systems —
-        practical lessons rather than theoretical overviews. I most often speak
-        on:
+        Hosting a conference, meetup, or podcast? I'd love to join you. I speak
+        from hands-on experience building real systems, with a focus on making
+        complex topics practical and accessible. Topics I cover include:
       </p>
       <ul class="mb-8 flex flex-wrap gap-3">
         {
@@ -82,4 +66,19 @@ const topics = [
       </a>
     </div>
   </section>
+
+  {
+    sorted.length > 0 && (
+      <section>
+        <div class="flex flex-col gap-10">
+          {sorted.map((entry) => (
+            <EventTimelineEntry
+              event={entry}
+              expanded={isUpcoming(entry.data.startDate)}
+            />
+          ))}
+        </div>
+      </section>
+    )
+  }
 </Layout>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,4 +19,5 @@
     "directory": "./dist",
     "not_found_handling": "404-page",
   },
+  "preview_urls": true,
 }


### PR DESCRIPTION
## Summary

- Adds an "Invite me to speak" section at the bottom of the Talks & Podcasts page
- Lists topic areas as pill badges: Distributed systems, Platform engineering, Databases, Agentic engineering
- Includes a `mailto:tyler@tylerbenfield.me?subject=Speaking%20Inquiry` CTA button
- Styled with the existing `glass gradient-border` card pattern, using `tokyo-purple` as the accent to visually differentiate from the cyan-accented header

## Test plan

- [ ] Visit `/events` and confirm the speaking section appears below the timeline
- [ ] Confirm topic pills render with correct purple styling
- [ ] Click "Get in touch" and verify it opens a mailto with the correct address and subject
- [ ] Verify no layout regressions on mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ejNJ8uZVUVqek8aZiZT97

---
_Generated by [Claude Code](https://claude.ai/code/session_018ejNJ8uZVUVqek8aZiZT97)_